### PR TITLE
Fix logo in FAQ section

### DIFF
--- a/faq(1).html
+++ b/faq(1).html
@@ -24,7 +24,7 @@
         <nav class="navbar fixed-top navbar-expand-md navbar-dark bg-transparent" id="page-navigation">
             <div class="container">
                 <!-- Navbar Brand -->
-                <a href="index(1).html" class="navbar-brand">
+                <a href="index.html" class="navbar-brand">
                     <img src="assets/img/logo/krishiconnect-high-resolution-logo-black-on-white-background.png" alt="">
                 </a>
 


### PR DESCRIPTION
fixing issue #74 

On clicking logo in FAQ page at top left corner, it was throwing an error.