### PR TITLE
Resolved Issue#275 Fixed Logo Dimensions on Shop Page 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "gfg",
+  "name": "krishiconnect",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/shop(1).html
+++ b/shop(1).html
@@ -85,7 +85,7 @@
         <div class="banner">
             <div class="jumbotron jumbotron-bg text-center rounded-0" style="background-image: url('assets/img/shop.png');">
                 <div class="container">
-                    <img src="assets/img/logo/log.png" alt="" height="300" width="400">
+                    <img src="assets/img/logo/log.png" alt="" height="300" width="300">
                     <h1 class="pt-5">
                         Shopping Page
                     </h1>

--- a/shop(1).html
+++ b/shop(1).html
@@ -85,7 +85,8 @@
         <div class="banner">
             <div class="jumbotron jumbotron-bg text-center rounded-0" style="background-image: url('assets/img/shop.png');">
                 <div class="container">
-                    <img src="assets/img/logo/log.png" alt="" height="300" width="300">
+                    <img src="assets/img/logo/log.png" alt="" height="300" 
+                        width="300">
                     <h1 class="pt-5">
                         Shopping Page
                     </h1>


### PR DESCRIPTION
This pull request addresses an issue where the square logo at the top of the shop page was not displaying with the correct dimensions, leading to a distorted appearance. To ensure visual consistency across the site, I have modified the logo dimensions to 300px height and 300px width. This change aligns the logo size with that of the transactions page, providing a uniform look and feel.







