### PR TITLE
Fix: Made text appear in both light and dark modes.

### DIFF
--- a/darkmode.css
+++ b/darkmode.css
@@ -85,3 +85,11 @@ input {
     transform: translateX(30px);
     /* Adjusted for smaller toggle width */
 }
+
+.dark{
+    .media-body{
+        p{
+            color: white;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #262 

The test in cards is now visible in both light and dark modes after making necessary changes.
In light mode:
![Screenshot 2024-05-25 190020](https://github.com/Anushkabh/krishiconnect/assets/121669832/138583cf-8b2d-421a-aa90-f5fb9de53c7e)
In dark mode:
![Screenshot 2024-05-25 190043](https://github.com/Anushkabh/krishiconnect/assets/121669832/d93e2421-72f5-43b8-bb1e-d95ace225689)
