### PR TITLE
Resolved Dark Mode Toggle Issue 

### DIFF
--- a/darkmode.js
+++ b/darkmode.js
@@ -1,12 +1,20 @@
- const body = document.querySelector("body");
-            const toggle = document.querySelector("#toggle");
-            const sunIcon = document.querySelector(".toggle .bxs-sun");
-            const moonIcon = document.querySelector(".toggle .bx-moon");
+const body = document.querySelector("body");
+const toggle = document.querySelector("#toggle");
+const sunIcon = document.querySelector(".toggle .bxs-sun");
+const moonIcon = document.querySelector(".toggle .bx-moon");
 
-            toggle.addEventListener("change", () => {
+function updateUI(isDarkMode) {
+    body.classList.toggle("dark", isDarkMode);
+    sunIcon.className = isDarkMode ? "bx bx-sun" : "bx bxs-sun";
+    moonIcon.className = isDarkMode ? "bx bxs-moon" : "bx bx-moon";
+}
 
-                body.classList.toggle("dark");
-                sunIcon.className = sunIcon.className == "bx bxs-sun" ? "bx bx-sun" : "bx bxs-sun";
-                moonIcon.className = moonIcon.className == "bx bxs-moon" ? "bx bx-moon" : "bx bxs-moon";
-  });
-        
+const isDarkMode = localStorage.getItem("darkMode") === "true";
+
+updateUI(isDarkMode);
+
+toggle.addEventListener("change", () => {
+    const isDarkMode = body.classList.toggle("dark");
+    localStorage.setItem("darkMode", isDarkMode);
+    updateUI(isDarkMode);
+});


### PR DESCRIPTION
hi @Anushkabh & @RitiChandak,
issue closes #428  
I have  resolved the issue to persist the dark mode preference across page refreshes using localStorage. 
The changes ensure that the user's selected mode (dark or light) is maintained even after the page is refreshed. 

Changes made are as follows : 
- Added functionality to check "localStorage" for the user's dark mode preference upon page load and set the initial state accordingly.
- Updated the event listener for the toggle switch to save the dark mode preference in localStorage whenever the user changes the mode.

Now, Whenever user will refresh or log in the page again, The selected mode preference will be the same as chosen.

Please take a look and review it.
Also, please add the labels.