### PR TITLE
Fix: Add email and phone links to the footer

### DIFF
--- a/assets/css/Footer-new.css
+++ b/assets/css/Footer-new.css
@@ -264,3 +264,8 @@
 .right-social-icn div {
   margin: 15px;
 }
+
+.footer-center-productlist-item a {
+  color: #ffffff; 
+  text-decoration: none; 
+}

--- a/index.html
+++ b/index.html
@@ -1568,11 +1568,12 @@
                 10012, US
               </p>
               <p>
-                <span><i class="fas fa-envelope me-3"> </i> </span
-                >krishiconnect@gmail.com
+                <span><i class="fas fa-envelope me-3"></i></span>
+                <a href="mailto:krishiconnect@gmail.com">krishiconnect@gmail.com</a>
               </p>
               <p>
-                <span><i class="fas fa-phone me-3"></i></span>082723 67238
+                <span><i class="fas fa-phone me-3"></i></span>
+                <a href="tel:+918272367238">082723 67238</a>
               </p>
             </div>
           </div>

--- a/src/blog.html
+++ b/src/blog.html
@@ -303,11 +303,12 @@
                 10012, US
               </p>
               <p>
-                <span><i class="fas fa-envelope me-3"> </i> </span
-                >krishiconnect@gmail.com
+                <span><i class="fas fa-envelope me-3"></i></span>
+                <a href="mailto:krishiconnect@gmail.com">krishiconnect@gmail.com</a>
               </p>
               <p>
-                <span><i class="fas fa-phone me-3"></i></span>082723 67238
+                <span><i class="fas fa-phone me-3"></i></span>
+                <a href="tel:+918272367238">082723 67238</a>
               </p>
             </div>
           </div>

--- a/src/cart.html
+++ b/src/cart.html
@@ -751,11 +751,12 @@
                 10012, US
               </p>
               <p>
-                <span><i class="fas fa-envelope me-3"> </i> </span
-                >krishiconnect@gmail.com
+                <span><i class="fas fa-envelope me-3"></i></span>
+                <a href="mailto:krishiconnect@gmail.com">krishiconnect@gmail.com</a>
               </p>
               <p>
-                <span><i class="fas fa-phone me-3"></i></span>082723 67238
+                <span><i class="fas fa-phone me-3"></i></span>
+                <a href="tel:+918272367238">082723 67238</a>
               </p>
             </div>
           </div>

--- a/src/contact.html
+++ b/src/contact.html
@@ -517,11 +517,12 @@
                 10012, US
               </p>
               <p>
-                <span><i class="fas fa-envelope me-3"> </i> </span
-                >krishiconnect@gmail.com
+                <span><i class="fas fa-envelope me-3"></i></span>
+                <a href="mailto:krishiconnect@gmail.com">krishiconnect@gmail.com</a>
               </p>
               <p>
-                <span><i class="fas fa-phone me-3"></i></span>082723 67238
+                <span><i class="fas fa-phone me-3"></i></span>
+                <a href="tel:+918272367238">082723 67238</a>
               </p>
             </div>
           </div>

--- a/src/contributors.html
+++ b/src/contributors.html
@@ -451,8 +451,14 @@
                     <h3>Contact US</h3>
                     <div class="footer-center-productlist-item">
                         <p> <span><i class="fas fa-home me-3"></i></span> New York, NY 10012, US</p>
-                        <p><span><i class="fas fa-envelope me-3"> </i> </span>krishiconnect@gmail.com</p>
-                        <p><span><i class="fas fa-phone me-3"></i></span>082723 67238</p>
+                        <p>
+                            <span><i class="fas fa-envelope me-3"></i></span>
+                            <a href="mailto:krishiconnect@gmail.com">krishiconnect@gmail.com</a>
+                          </p>
+                          <p>
+                            <span><i class="fas fa-phone me-3"></i></span>
+                            <a href="tel:+918272367238">082723 67238</a>
+                          </p>
                     </div>
                 </div>
             </div>

--- a/src/shop.html
+++ b/src/shop.html
@@ -2706,11 +2706,12 @@ body.dark .gray-bag{
                 10012, US
               </p>
               <p>
-                <span><i class="fas fa-envelope me-3"> </i> </span
-                >krishiconnect@gmail.com
+                <span><i class="fas fa-envelope me-3"></i></span>
+                <a href="mailto:krishiconnect@gmail.com">krishiconnect@gmail.com</a>
               </p>
               <p>
-                <span><i class="fas fa-phone me-3"></i></span>082723 67238
+                <span><i class="fas fa-phone me-3"></i></span>
+                <a href="tel:+918272367238">082723 67238</a>
               </p>
             </div>
           </div>

--- a/src/transaction.html
+++ b/src/transaction.html
@@ -490,11 +490,12 @@
                 10012, US
               </p>
               <p>
-                <span><i class="fas fa-envelope me-3"> </i> </span
-                >krishiconnect@gmail.com
+                <span><i class="fas fa-envelope me-3"></i></span>
+                <a href="mailto:krishiconnect@gmail.com">krishiconnect@gmail.com</a>
               </p>
               <p>
-                <span><i class="fas fa-phone me-3"></i></span>082723 67238
+                <span><i class="fas fa-phone me-3"></i></span>
+                <a href="tel:+918272367238">082723 67238</a>
               </p>
             </div>
           </div>

--- a/src/vegetables.html
+++ b/src/vegetables.html
@@ -2182,11 +2182,12 @@
                 10012, US
               </p>
               <p>
-                <span><i class="fas fa-envelope me-3"> </i> </span
-                >krishiconnect@gmail.com
+                <span><i class="fas fa-envelope me-3"></i></span>
+                <a href="mailto:krishiconnect@gmail.com">krishiconnect@gmail.com</a>
               </p>
               <p>
-                <span><i class="fas fa-phone me-3"></i></span>082723 67238
+                <span><i class="fas fa-phone me-3"></i></span>
+                <a href="tel:+918272367238">082723 67238</a>
               </p>
             </div>
           </div>

--- a/src/wishlist.html
+++ b/src/wishlist.html
@@ -639,11 +639,12 @@
             10012, US
           </p>
           <p>
-            <span><i class="fas fa-envelope me-3"> </i> </span
-            >krishiconnect@gmail.com
+            <span><i class="fas fa-envelope me-3"></i></span>
+            <a href="mailto:krishiconnect@gmail.com">krishiconnect@gmail.com</a>
           </p>
           <p>
-            <span><i class="fas fa-phone me-3"></i></span>082723 67238
+            <span><i class="fas fa-phone me-3"></i></span>
+            <a href="tel:+918272367238">082723 67238</a>
           </p>
         </div>
       </div>


### PR DESCRIPTION
### **PR Description**:
This PR addresses issue [#947](https://github.com/Anushkabh/krishiconnect/issues/947) by adding missing clickable **email** and **phone number** links in the footer. The changes involve the following:

- **Email**: Added a `mailto:` link for the email address (e.g., `krishiconnect@gmail.com`).
- **Phone**: Added a `tel:` link for the phone number (e.g., `082723 67238`).

Additionally, I have made the following updates across multiple files to ensure these links appear correctly and are styled as intended:

### **Modified Files**:
1. **HTML Files**:
   - `index.html`
   - `src/blog.html`
   - `src/cart.html`
   - `src/contact.html`
   - `src/contributors.html`
   - `src/shop.html`
   - `src/transaction.html`
   - `src/vegetables.html`
   - `src/wishlist.html`

   These files have been updated to include the new clickable `mailto:` and `tel:` links in the footer section.

2. **CSS File**:
   - `assets/css/Footer-new.css`

   I made changes to this CSS file to override the default styles, ensuring that the email and phone links do not display in the default blue color. This prevents the links from appearing as standard hyperlinks and ensures they are styled consistently with the rest of the footer.

---

### **Summary of Changes**:
- Added clickable **email** and **phone** links in the footer across multiple pages.
- Updated **Footer-new.css** to ensure the links are styled correctly and don’t appear blue.
- Ensured consistent footer design across different pages by updating the relevant HTML and CSS files.

Please review the changes, and let me know if any adjustments are needed.