### PR TITLE
Fix: Remove duplicate "Rate Us" link from navbar on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -790,9 +790,7 @@
                   ><i class="ri-user-star-fill"></i>Rate Us</a
                 >
 
-                <a href="./src/rateus.html" class="nav-link">
-                  <i class="ri-user-star-fill"></i> RateUs
-                </a>
+                
 
               </li>
             </ul>


### PR DESCRIPTION
This PR addresses the issue identified in #949, where there were two "Rate Us" links in the navbar on the index page. The duplicate link has been removed, leaving only one "Rate Us" link.

### Files Changed:
- `index.html` (Navbar section)

This fix ensures a cleaner and more intuitive navbar with only one "Rate Us" link.
